### PR TITLE
docs: update according to `@interep/reputation:0.5.0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,8 @@ If you want to use the reputation service APIs with a JavaScript library you can
 :::
 
 :::info
+
+[//]: # (TODO update?)
 Interep APIs are currently available for the following Ethereum networks: `kovan`, `goerli`.
 :::
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -63,7 +63,7 @@ curl https://kovan.interep.link/api/v1/groups
     "data": [
         {
             "provider": "twitter",
-            "name": "gold",
+            "name": "star",
             "depth": 20,
             "root": "19217088683336594659449020493828377907203207941212636669271704950158751593251",
             "onchainRoot": "19217088683336594659449020493828377907203207941212636669271704950158751593251",
@@ -107,14 +107,14 @@ curl https://kovan.interep.link/api/v1/groups
 **GET** - Returns a specific Interep group.
 
 ```bash title="Shell"
-curl https://kovan.interep.link/api/v1/groups/github/gold
+curl https://kovan.interep.link/api/v1/groups/github/established
 ```
 
 ```json title="Response"
 {
     "data": {
         "provider": "github",
-        "name": "gold",
+        "name": "established",
         "depth": 20,
         "root": "3539596833905557328479676245499052267688962849195984401151716846778908697643",
         "onchainRoot": "3539596833905557328479676245499052267688962849195984401151716846778908697643",
@@ -129,7 +129,7 @@ curl https://kovan.interep.link/api/v1/groups/github/gold
 **GET** - Returns the group members.
 
 ```bash title="Shell"
-curl https://kovan.interep.link/api/v1/groups/github/gold/members?limit=0&offset=0
+curl https://kovan.interep.link/api/v1/groups/github/established/members?limit=0&offset=0
 ```
 
 ```json title="Response"
@@ -146,7 +146,7 @@ curl https://kovan.interep.link/api/v1/groups/github/gold/members?limit=0&offset
 **GET** - Returns true if an identity commitment belongs to a group.
 
 ```bash title="Shell"
-curl https://kovan.interep.link/api/v1/groups/github/gold/5389624958916554855745402699919973897274778066321592214684792070525465486554
+curl https://kovan.interep.link/api/v1/groups/github/established/5389624958916554855745402699919973897274778066321592214684792070525465486554
 ```
 
 ```json title="Response"
@@ -157,7 +157,7 @@ curl https://kovan.interep.link/api/v1/groups/github/gold/5389624958916554855745
 
 ```bash title="Shell"
 curl -X POST -H "Authorization: token OAUTH-TOKEN" \
-https://kovan.interep.link/api/v1/groups/github/gold/5389624958916554855745402699919973897274778066321592214684792070525465486554
+https://kovan.interep.link/api/v1/groups/github/established/5389624958916554855745402699919973897274778066321592214684792070525465486554
 ```
 
 ```json title="Response"
@@ -169,7 +169,7 @@ https://kovan.interep.link/api/v1/groups/github/gold/538962495891655485574540269
 **GET** - Returns a Merkle tree proof.
 
 ```bash title="Shell"
-curl https://kovan.interep.link/api/v1/groups/github/gold/6014393454173820032764441533619576647480292883965697181546606218195926726207/proof
+curl https://kovan.interep.link/api/v1/groups/github/established/6014393454173820032764441533619576647480292883965697181546606218195926726207/proof
 ```
 
 ```json title="Response"
@@ -248,7 +248,7 @@ curl https://kovan.interep.link/api/v1/batches
 {
     "data": [
         {
-            "group": { "provider": "github", "name": "gold" },
+            "group": { "provider": "github", "name": "established" },
             "roots": ["14273848199791178467311820318933280591305571798471599149384455313172966875782"],
             "transaction": {
                 "hash": "0x1dec16b1c76a0a1fc9b4c7c898ae0ba72f496868fb7d2fe447fefe5eeaf676c1",
@@ -256,7 +256,7 @@ curl https://kovan.interep.link/api/v1/batches
             }
         },
         {
-            "group": { "provider": "github", "name": "gold" },
+            "group": { "provider": "github", "name": "established" },
             "roots": [
                 "19217088683336594659449020493828377907203207941212636669271704950158751593251",
                 "3539596833905557328479676245499052267688962849195984401151716846778908697643"
@@ -281,7 +281,7 @@ curl https://kovan.interep.link/api/v1/batches/353959683390555732847967624549905
 ```json title="Response"
 {
     "data": {
-        "group": { "provider": "github", "name": "gold" },
+        "group": { "provider": "github", "name": "established" },
         "roots": [
             "19217088683336594659449020493828377907203207941212636669271704950158751593251",
             "3539596833905557328479676245499052267688962849195984401151716846778908697643"
@@ -324,6 +324,6 @@ If you don't know GraphQL, you can try running some queries using the Graph Expl
 
 -   `id`: unique identifier among all group entities,
 -   `provider`: Interep group provider (e.g. `twitter`),
--   `name`: Interep group name (e.g. `gold`),
+-   `name`: Interep group name (e.g. `established`),
 -   `depth`: Merkle tree depth,
 -   `root`: Merkle tree root hash.

--- a/docs/guides/generating-proofs.md
+++ b/docs/guides/generating-proofs.md
@@ -51,7 +51,7 @@ Creating Semaphore proofs also requires some zero-knowledge static files. In the
 import createProof from "@interep/proof"
 
 const groupProvider = "github"
-const groupName = "gold"
+const groupName = "established"
 const externalNullifier = 1
 const signal = "Hello World"
 

--- a/docs/guides/interep-groups.md
+++ b/docs/guides/interep-groups.md
@@ -28,15 +28,11 @@ Once you have generated a valid OAuth token and you are able to obtain the user'
 import { calculateReputation, OAuthProvider } from "@interep/reputation"
 
 // 'getGithubUserByToken' is an example function.
-const { id, plan, followers, receivedStars } = await getGithubUserByToken(token)
+const { receivedStars, sponsorsCount, sponsoringCount } = await getGithubUserByToken(token)
 
-const reputation = calculateReputation(OAuthProvider.GITHUB, {
-    proPlan: plan.name === "pro",
-    followers,
-    receivedStars
-})
+const reputation = calculateReputation(OAuthProvider.GITHUB, { receivedStars, sponsorsCount, sponsoringCount })
 
-console.log(reputation) // gold
+console.log(reputation) // established
 ```
 
 ## Semaphore identity

--- a/docs/technical-reference/groups/oauth.md
+++ b/docs/technical-reference/groups/oauth.md
@@ -38,5 +38,5 @@ Allocating funds towards public goods efficiently, safely, and fairly is a compl
 Currently, there are three OAuth providers: Twitter, GitHub and Reddit. For each of them there will be one of the following groups based on the user's reputation level: **`commoner`**, **`up-and-coming`**, **`established`**, **`star`** and **`icon`**.
 
 :::info
-If you want to know how InterRep calculates reputation click [here](/technical-reference/reputation/intro).
+If you want to know how Interep calculates reputation click [here](/technical-reference/reputation/intro).
 :::

--- a/docs/technical-reference/groups/oauth.md
+++ b/docs/technical-reference/groups/oauth.md
@@ -35,8 +35,8 @@ Allocating funds towards public goods efficiently, safely, and fairly is a compl
 
 ## Available groups
 
-Currently there are three OAuth providers: Twitter, Github and Reddit. For each of them there will be one of the following groups based on the user's reputation level: **`gold`**, **`silver`**, **`bronze`**.
+Currently, there are three OAuth providers: Twitter, GitHub and Reddit. For each of them there will be one of the following groups based on the user's reputation level: **`commoner`**, **`up-and-coming`**, **`established`**, **`star`** and **`icon`**.
 
 :::info
-If you want to know how Interep calculates reputation click [here](/technical-reference/reputation/intro).
+If you want to know how InterRep calculates reputation click [here](/technical-reference/reputation/intro).
 :::

--- a/docs/technical-reference/reputation/github.md
+++ b/docs/technical-reference/reputation/github.md
@@ -2,73 +2,13 @@
 
 ## Parameters
 
--   **Followers**: number of the user's followers;
--   **Received stars**: sum of the number of stars received in the user's repositories;
--   **Plan**: true if the user has subscribed to a pro plan, false otherwise.
+-   **Received stars**: sum of stars received across all user's public repositories.
+-   **Sponsors count**: number of other organizations/users sponsoring the user.
+-   **Sponsoring count**: number of other organizations/users the user is sponsoring.
 
 ## Levels
 
-### Gold
-
-```typescript
-[
-    {
-        parameter: "followers",
-        value: {
-            min: 500
-        }
-    },
-    {
-        parameter: "receivedStars",
-        value: {
-            min: 200
-        }
-    }
-]
-```
-
-### Silver
-
-```typescript
-[
-    {
-        parameter: "followers",
-        value: {
-            min: 100
-        }
-    },
-    {
-        parameter: "receivedStars",
-        value: {
-            min: 80
-        }
-    }
-]
-```
-
-### Bronze
-
-```typescript
-[
-    {
-        parameter: "proPlan",
-        value: true
-    },
-    {
-        parameter: "followers",
-        value: {
-            min: 50
-        }
-    },
-    {
-        parameter: "receivedStars",
-        value: {
-            min: 40
-        }
-    }
-]
-```
-
----
-
-#### Configuration file: [src/criteria/github.ts](https://github.com/interep-project/interep.js/blob/main/packages/reputation/src/criteria/github.ts)
+|               stars                |       0       |     < 10      |     < 100     |  < 1000  | +1000 |
+|:----------------------------------:|:-------------:|:-------------:|:-------------:|:--------:|:-----:|
+|  neither sponsored nor sponsoring  |   commoner    | up-and-coming |  established  |   star   | icon  |
+|       sponsors or sponsoring       |  established  |  established  |  established  |   star   | icon  |

--- a/docs/technical-reference/reputation/intro.md
+++ b/docs/technical-reference/reputation/intro.md
@@ -5,8 +5,13 @@ title: Introduction
 
 # Reputation
 
-The heart of Interep lies in the possibility to export reputation. However, calculating it is not an easy task, at least as far as social networks are concerned. Some parameters are easier to fake and others do not offer an objective representation of the user's reputation. Our methods try to select the most suitable parameters and calculate a score that falls into one of the following categories (or reputation levels): `gold`, `silver`, `bronze`. Parameters such as `followers`, `likes`, `stars` can then be used to obtain a score that can best represent the authenticity of a user. The following paragraphs describe the criteria used by the social media platforms supported by Interep.
+The heart of Interep lies in the possibility to export reputation.
+However, calculating reputation is not an easy task, at least as far as social networks are concerned.
+Some parameters are easier to fake and others do not offer an objective representation of the user's reputation.
+Based on [analysis of public data](https://github.com/interep-project/interep-groups-eda) collected from each reputation network (github, reddit, twitter) we tried to select and combine parameters that both reflect user's authenticity and result in reputation levels of decreasing sizes.
+We defined the following reputation levels: `commoner`, `up-and-coming`, `established`, `star` and `icon`.
+The following paragraphs describe the criteria used for each of the social media platforms supported by Interep.
 
 :::tip
-If you want to see how we calculate reputation or if you want to integrate our methods into your app, we have a dedicated [`@interep/reputation`](https://github.com/interep-project/interep.js/tree/main/packages/reputation) package.
+If you want to see how we calculate reputation more in details or if you want to integrate our methods into your application, we have a dedicated [`@interep/reputation`](https://github.com/interep-project/interep.js/tree/main/packages/reputation) package.
 :::

--- a/docs/technical-reference/reputation/reddit.md
+++ b/docs/technical-reference/reputation/reddit.md
@@ -2,86 +2,12 @@
 
 ## Parameters
 
--   **Premium subscription**: true if the user has subscribed to a premium plan, false otherwise;
--   **Karma**: amount of user's karma;
--   **Coins**: amount of user's coins;
--   **Linked identities**: number of identities linked to the account (e.g. Twitter, Google).
+-   **Total karma**: total [karma](https://reddit.zendesk.com/hc/en-us/articles/204511829-What-is-karma-) earned by the user across all subreddits.
+-   **Is gold**: whether the user has a [gold award](https://en.reddit.com/coins).
 
 ## Levels
 
-### Gold
-
-```typescript
-[
-    {
-        parameter: "premiumSubscription",
-        value: true
-    },
-    {
-        parameter: "karma",
-        value: {
-            min: 10000
-        }
-    },
-    {
-        parameter: "coins",
-        value: {
-            min: 5000
-        }
-    },
-    {
-        parameter: "linkedIdentities",
-        value: {
-            min: 3
-        }
-    }
-]
-```
-
-### Silver
-
-```typescript
-[
-    {
-        parameter: "karma",
-        value: {
-            min: 5000
-        }
-    },
-    {
-        parameter: "coins",
-        value: {
-            min: 2000
-        }
-    },
-    {
-        parameter: "linkedIdentities",
-        value: {
-            min: 2
-        }
-    }
-]
-```
-
-### Bronze
-
-```typescript
-[
-    {
-        parameter: "karma",
-        value: {
-            min: 1000
-        }
-    },
-    {
-        parameter: "coins",
-        value: {
-            min: 500
-        }
-    }
-]
-```
-
----
-
-#### Configuration file: [src/criteria/reddit.ts](https://github.com/interep-project/interep.js/blob/main/packages/reputation/src/criteria/reddit.ts)
+|total karma|     < 2k      |< 20k|< 100k|< 200k| +200k |
+|:-----------------:|:-------------:|:---:|:----:|:----:|:-----:|
+|is gold| up-and-coming |up-and-coming|established|star| icon  |
+|is not gold|   commoner    |up-and-coming|established|star| icon  |

--- a/docs/technical-reference/reputation/twitter.md
+++ b/docs/technical-reference/reputation/twitter.md
@@ -2,73 +2,14 @@
 
 ## Parameters
 
--   **Followers**: number of the user's followers;
--   **Botometer overall score**: score obtained with [Botometer](https://botometer.osome.iu.edu/);
--   **Verified profile**: true if the user has a verifier profile, false otherwise.
+-   **Followers**: number of followers of the user;
+-   **Botometer overall score**: "Complete Automation Probability" score (`cap`) calculated by [Botometer](https://botometer.iuni.iu.edu/#!/) (a tool for measuring the probability that a Twitter account is run by a bot).
+-   **Verified profile**: whether the user has a verified profile.
 
 ## Levels
-
-### Gold
-
-```typescript
-[
-    {
-        parameter: "verifiedProfile",
-        value: true
-    },
-    {
-        parameter: "followers",
-        value: {
-            min: 7000
-        }
-    },
-    {
-        parameter: "botometerOverallScore",
-        value: {
-            max: 1
-        }
-    }
-]
-```
-
-### Silver
-
-```typescript
-[
-    {
-        parameter: "followers",
-        value: {
-            min: 2000
-        }
-    },
-    {
-        parameter: "botometerOverallScore",
-        value: {
-            max: 1.5
-        }
-    }
-]
-```
-
-### Bronze
-
-```typescript
-[
-    {
-        parameter: "followers",
-        value: {
-            min: 500
-        }
-    },
-    {
-        parameter: "botometerOverallScore",
-        value: {
-            max: 2
-        }
-    }
-]
-```
-
----
-
-#### Configuration file: [src/criteria/twitter.ts](https://github.com/interep-project/interep.js/blob/main/packages/reputation/src/criteria/twitter.ts)
+|                         followers                         |    < 100    |     < 1k      |    < 10k    |  < 100k  |  +100k   |
+|:---------------------------------------------------------:|:-----------:|:-------------:|:-----------:|:--------:|:--------:|
+|          is likely bot (botometer `cap` >= 0.95)          |  commoner   |   commoner    |  commoner   | commoner | commoner |
+| is likely not bot (botometer `cap` < 0.95) & not verified |  commoner   | up-and-coming | established |   star   |   icon   |
+| is likely not bot (botometer `cap` < 0.95) & not verified |  commoner   | up-and-coming | established |   star   |   icon   |
+|   is likely not bot (botometer `cap` < 0.95) & verified   | established |  established  | established |   star   |   icon   |


### PR DESCRIPTION
Update documentation sections impacted by changes introduced by https://github.com/interep-project/interep.js/pull/9

Changes are mostly in the `/technical-reference/reputation` section and copy pasted from https://github.com/interep-project/interep-groups-eda#reputation